### PR TITLE
Check by printing version number, instead of converting image

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,7 @@ var bin = new BinWrapper()
  */
 fs.exists(bin.use(), function (exists) {
   if (!exists) {
-    var args = [
-      path.join(__dirname, 'test/fixtures/test.png'),
-      '-o',
-      path.join(__dirname, 'test/fixtures/test.webp')
-    ];
-
-    bin.run(args, function (error) {
+    bin.run('-version', function (error) {
       if (error) {
         console.log(chalk.red('✗ pre-build test failed, compiling from source...'));
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
   },
   "files": [
     "cli.js",
-    "index.js",
-    "test"
+    "index.js"
   ],
   "keywords": [
     "image",


### PR DESCRIPTION
By printing the version number simply, we can check if the `cwebp` binary works or not. So we don't need to include `test` directory in the npm package.
