### PR TITLE
Remove description of the dependencies on Mac OS X

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,20 +21,12 @@ But if PNG (event though 8-bit converted!) contains many colors, it depends.
 
 In most cases, WebP images are smaller than JPEG images.
 
-## Dependency
+## Dependencies on Linux
 
-WebP requires following libraries. See [detail](https://developers.google.com/speed/webp/docs/compiling).
-
-### Linux
+WebP requires following libraries on Linux. See [detail](https://developers.google.com/speed/webp/docs/compiling#compiling_on_unix-like_platforms).
 
 ```sh
 $ sudo apt-get install libjpeg-dev libpng-dev libtiff-dev libgif-dev
-```
-
-### Mac OS X
-
-```sh
-$ sudo port install jpeg libpng tiff giflib
 ```
 
 ## Install


### PR DESCRIPTION
According to [the WebP documentation](https://developers.google.com/speed/webp/docs/precompiled#getting_cwebp_dwebp_and_the_webp_libraries):

> Conversely, the libpng, libjpeg and libtiff libraries have been statically linked in the Mac OS X binaries. They do not require additional installation.

So we can use the `cwebp` binary without any dependencies on Mac OS X.
