### PR TITLE
Update download URLs to v1.0.0

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -10,7 +10,7 @@ bin.run(['-version'], err => {
 		log.info('compiling from source');
 
 		const builder = new BinBuild()
-			.src('http://downloads.webmproject.org/releases/webp/libwebp-0.6.1.tar.gz')
+			.src('http://downloads.webmproject.org/releases/webp/libwebp-1.0.0.tar.gz')
 			.cmd(`./configure --disable-shared --prefix="${bin.dest()}" --bindir="${bin.dest()}"`)
 			.cmd('make && make install');
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ const cwebp = require('..');
 test.cb('rebuild the cwebp binaries', t => {
 	const tmp = tempy.directory();
 	const builder = new BinBuild()
-		.src('http://downloads.webmproject.org/releases/webp/libwebp-0.5.1.tar.gz')
+		.src('http://downloads.webmproject.org/releases/webp/libwebp-1.0.0.tar.gz')
 		.cmd(`./configure --disable-shared --prefix="${tmp}" --bindir="${tmp}"`)
 		.cmd('make && make install');
 


### PR DESCRIPTION
Updated URLs to point to v1.0.0 release source.

I'll let a maintainer download the pre-compiled binaries:
https://storage.googleapis.com/downloads.webmproject.org/releases/webp/index.html

Or the non-HTTPs source:
http://downloads.webmproject.org/releases/webp/index.html