### PR TITLE
Drop Node.js 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
         node-version:
           - 16
           - 14
-          - 12
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"cwebp": "cli.js"
 	},
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": "^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
 		"postinstall": "node lib/install.js",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
 		"bin-wrapper": "^4.0.1"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
+		"ava": "^4.1.0",
 		"bin-check": "^4.1.0",
 		"compare-size": "^3.0.0",
-		"execa": "^5.1.1",
+		"execa": "^6.1.0",
 		"tempy": "^2.0.0",
-		"xo": "^0.45.0"
+		"xo": "^0.48.0"
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import process from 'node:process';
 import {fileURLToPath} from 'node:url';
 import test from 'ava';
-import execa from 'execa';
+import {execa} from 'execa';
 import tempy from 'tempy';
 import binCheck from 'bin-check';
 import binBuild from 'bin-build';
@@ -34,7 +34,7 @@ test('return path to binary and verify that it is working', async t => {
 
 test('minify and convert a PNG to WebP', async t => {
 	const temporary = tempy.directory();
-	const src = fileURLToPath(new URL('./fixtures/test.png', import.meta.url));
+	const src = fileURLToPath(new URL('fixtures/test.png', import.meta.url));
 	const dest = path.join(temporary, 'test-png.webp');
 	const args = [
 		src,
@@ -50,7 +50,7 @@ test('minify and convert a PNG to WebP', async t => {
 
 test('minify and convert a JPG to WebP', async t => {
 	const temporary = tempy.directory();
-	const src = fileURLToPath(new URL('./fixtures/test.jpg', import.meta.url));
+	const src = fileURLToPath(new URL('fixtures/test.jpg', import.meta.url));
 	const dest = path.join(temporary, 'test-jpg.webp');
 	const args = [
 		src,


### PR DESCRIPTION
Node.js 12 is going to be outdated in the near future ([2022-04-30](https://nodejs.org/en/about/releases/)).